### PR TITLE
added config to overwrite parent with child

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ custom:
     maxLevels: 2     # Optional (Default 3)
 ```  
 
+Per default the parent file will overwrite settings in the service files. If you want the service file to have a
+higher priority you can change that using
+```yaml
+custom:
+  parent:
+    overwriteServiceConfig: false     # Optional (Default true)
+```  
+
 ##### Project Structure
 
 ```

--- a/example/service1/serverless.yml
+++ b/example/service1/serverless.yml
@@ -4,8 +4,44 @@ plugins:
   - serverless-plugin-parent
 
 provider:
+  # Overwrites runtime from parent
+  runtime: nodejs10.x
   environment:
     HELLO_MESSAGE: Mholo
+
+
+custom:
+  parent:
+     overwriteServiceConfig: false
+
+resources:
+  Resources:
+  # Overwrites DefaultRole from parent
+    DefaultRole:
+      Type: AWS::IAM::Role
+      Properties:
+        Path: /
+        RoleName: ${self:service}-${self:provider.stage}_child
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service:
+                  - lambda.amazonaws.com
+              Action: sts:AssumeRole
+        Policies:
+          - PolicyName: ${self:service}-${self:provider.stage}_child
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - logs:CreateLogGroup
+                    - logs:CreateLogStream
+                    - logs:PutLogEvents
+                  Resource: arn:aws:logs:${self:provider.region}:*:log-group:/aws/lambda/*:*:*
+
 
 functions:
   Hello:

--- a/src/index.js
+++ b/src/index.js
@@ -99,9 +99,29 @@ class ServerlessPluginParent {
         const parentConfigurationFilename = this.getParentConfigurationRelativePath();
 
         const parentConfiguration = this.serverless.utils.readFileSync(parentConfigurationFilename);
+        
+        // save old config for later use
+        const userServiceConfig = _.merge({}, this.serverless.service)
 
         this.serverless.service = _.merge(this.serverless.service || {}, parentConfiguration);
-    }
+
+        let overwriteServiceConfig = true
+        if (
+          this.serverless.service.custom !== undefined &&
+          this.serverless.service.custom.parent !== undefined &&
+          this.serverless.service.custom.parent.overwriteServiceConfig === false
+        ) {
+          overwriteServiceConfig = false
+        } 
+
+        // overwrites service config with parent config
+        this.serverless.service = _.merge(this.serverless.service || {}, parentConfiguration)
+
+        if (!overwriteServiceConfig) {
+          // overwrites config again with old service file
+          this.serverless.service = _.merge(this.serverless.service, userServiceConfig)
+        }
+    } 
 
     /**
      * Search service paths recursively for Serverless configration fragment files


### PR DESCRIPTION
Added a config parameter that enables to overwrite the parent configuration with the child configuration.
Kept defaults to mitigate compatibility issues.
Resolves #3 