### PR TITLE
Updates for serverless ^3.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "bluebird": "^3.5.1",
     "js-yaml": "^3.11.0",
     "lodash": "^4.17.10"
+  },
+  "peerDependencies":{
+    "serverless": "^3.26.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,7 @@ class ServerlessPluginParent {
             configurationPathKeys = []
         }
 
-        if (typeof value == 'object'){
+        if (value && typeof value == 'object'){
             Object.keys(value).forEach(key => {
                   this.extendServiceConfigurationWithObject(this.appendConfigurationPathKey(configurationPathKeys, key), value[key]);
                 });

--- a/src/index.js
+++ b/src/index.js
@@ -103,36 +103,7 @@ class ServerlessPluginParent {
 
         const parentConfiguration = this.serverless.utils.readFileSync(parentConfigurationFilename);
         
-        // save old config for later use
-        const userServiceConfig = _.merge({}, this.serverless.service)
-
-        this.serverless.service = _.merge(this.serverless.service || {}, parentConfiguration);
-
-        let overwriteServiceConfig = true
-        if (
-          this.serverless.service.custom !== undefined &&
-          this.serverless.service.custom.parent !== undefined &&
-          this.serverless.service.custom.parent.overwriteServiceConfig === false
-        ) {
-          overwriteServiceConfig = false
-        } 
-
-        // overwrites service config with parent config
-        this.serverless.service = _.merge(this.serverless.service || {}, parentConfiguration)
-
-        if (!overwriteServiceConfig) {
-          // overwrites config again with old service file
-          this.serverless.service = _.merge(this.serverless.service, userServiceConfig)
-        }
-
-        //
-        // after serverless@2.26.0. variables are resolved before the plugins are called
-        // thus we need to explicitly repopulate variables after merging the fragments
-        //
-        if (this.serverless.variables && this.serverless.variables.populateService && 
-            typeof this.serverless.variables.populateService === 'function') {
-            this.serverless.variables.populateService(this.serverless.pluginManager.cliOptions);        
-        }
+        this.extendServiceConfigurationWithObject([],parentConfiguration);
     } 
 
     /**
@@ -175,6 +146,44 @@ class ServerlessPluginParent {
 
         return path.join(relativePath, "serverless.yml");
     };
+
+    /**
+     * Append a key to the list of configurationPathKeys
+     *
+     * @param configurationPathKeys
+     * @param key
+     */
+    appendConfigurationPathKey(configurationPathKeys, key){
+        let keys_ = _.cloneDeep(configurationPathKeys)
+        keys_.push(key)
+        return keys_;
+    }
+
+    /**
+     * Extend the serverless Configuration with and object
+     *
+     * @param configurationPathKeys array of path keys e.g. [['provider'],['name']]
+     * @param value e.g. aws
+     */
+    extendServiceConfigurationWithObject(configurationPathKeys, value){
+
+        if (!configurationPathKeys){
+            configurationPathKeys = []
+        }
+
+        if (typeof value == 'object'){
+            Object.keys(value).forEach(key => {
+                  this.extendServiceConfigurationWithObject(this.appendConfigurationPathKey(configurationPathKeys, key), value[key]);
+                });
+        }
+        else if (Array.isArray(value)){
+            value.forEach((element) => this.extendServiceConfigurationWithObject(configurationPathKeys, element));
+        }
+        else if (value){
+            this.serverless.extendConfiguration(configurationPathKeys, value);
+        }
+    }
+
 }
 
 /** Export ServerlessPluginParent class */

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,10 @@ class ServerlessPluginParent {
      * @returns {Promise}
      */
     printParentUsage() {
-        this.serverless.cli.generateCommandsHelp(["parent"]);
+
+        if (this.serverless.cli.generateCommandsHelp){
+            this.serverless.cli.generateCommandsHelp(["parent"]);    
+        }
 
         return BbPromise.resolve();
     }
@@ -120,6 +123,15 @@ class ServerlessPluginParent {
         if (!overwriteServiceConfig) {
           // overwrites config again with old service file
           this.serverless.service = _.merge(this.serverless.service, userServiceConfig)
+        }
+
+        //
+        // after serverless@2.26.0. variables are resolved before the plugins are called
+        // thus we need to explicitly repopulate variables after merging the fragments
+        //
+        if (this.serverless.variables && this.serverless.variables.populateService && 
+            typeof this.serverless.variables.populateService === 'function') {
+            this.serverless.variables.populateService(this.serverless.pluginManager.cliOptions);        
         }
     } 
 


### PR DESCRIPTION
After 2.25.0 this plugin stopped working.  There was a re-write of the variable handling and it became difficult to dynamically register external entries to the service configuration.

In 3.26.0 a new API was added support parsing of variables.
```serverless.extendConfiguration(configurationPathKeys, value);```

This updates to use the new API.